### PR TITLE
Remove '.\' and './' prefixes from filenames

### DIFF
--- a/src/CUEParser.cpp
+++ b/src/CUEParser.cpp
@@ -81,6 +81,7 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size)
             }
 
             const char *p = read_quoted(m_parse_pos + 5, m_track_info.filename, sizeof(m_track_info.filename));
+            remove_dot_slash(m_track_info.filename, sizeof(m_track_info.filename));
             m_track_info.file_mode = parse_file_mode(skip_space(p));
             m_track_info.file_offset = 0;
             m_track_info.file_index++;
@@ -307,5 +308,13 @@ uint32_t CUEParser::get_sector_length(CUEFileMode filemode, CUETrackMode trackmo
     else
     {
         return 0;
+    }
+}
+
+void CUEParser::remove_dot_slash(char * filename, size_t length)
+{
+    if (strncasecmp(filename, "./", 2) == 0 || strncasecmp(filename, ".\\", 2) == 0)
+    {
+        memmove(filename, filename + 2, length - 2);
     }
 }

--- a/src/CUEParser.h
+++ b/src/CUEParser.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifndef CUE_MAX_FILENAME
 #define CUE_MAX_FILENAME 64
@@ -132,4 +133,7 @@ protected:
 
     // Get sector length in file from track mode
     uint32_t get_sector_length(CUEFileMode filemode, CUETrackMode trackmode);
+
+    // Remove './' or '.\' from the beginning of the filename as it is not recogized by the SDFat library
+    void remove_dot_slash(char* filename, size_t length);
 };


### PR DESCRIPTION
The SDFat library doesn't work with '.\' or './', this removes them from the track info when the CUEParser is parsing the filename from a multi bin cue sheet.