### PR TITLE
Fix/long filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/*_test

--- a/src/CUEParser.h
+++ b/src/CUEParser.h
@@ -23,7 +23,7 @@
 #include <stddef.h>
 
 #ifndef CUE_MAX_FILENAME
-#define CUE_MAX_FILENAME 64
+#define CUE_MAX_FILENAME 256
 #endif
 
 enum CUEFileMode

--- a/test/CUEParser_test.cpp
+++ b/test/CUEParser_test.cpp
@@ -341,9 +341,40 @@ FILE ".\track2.bin" BINARY
     return status;
 }
 
+bool test_long_filename()
+{
+    bool status = true;
+    const char *cue_sheet = R"(
+CATALOG 0000000000000
+FILE "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.bin" BINARY
+  TRACK 01 MODE1/2352
+    INDEX 01 00:00:00
+    )";
+
+    CUEParser parser(cue_sheet);
+    COMMENT("test_long_filename()");
+    COMMENT("Test TRACK 01 (data)");
+    const CUETrackInfo *track = parser.next_track(0);
+    TEST(track != NULL);
+    if (track)
+    {
+        TEST(strcmp(track->filename, "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.bin") == 0);
+        TEST(track->file_mode == CUEFile_BINARY);
+        TEST(track->file_offset == 0);
+        TEST(track->file_index == 1);
+        TEST(track->track_number == 1);
+        TEST(track->track_mode == CUETrack_MODE1_2352);
+        TEST(track->sector_length == 2352);
+        TEST(track->unstored_pregap_length == 0);
+        TEST(track->data_start == 0);
+        TEST(track->track_start == 0);
+    }
+    return status;
+}
+
 int main()
 {
-    if (test_basics() && test_datatracks() && test_datatrackpregap() && test_multifile() && test_dot_slash_removal())
+    if (test_basics() && test_datatracks() && test_datatrackpregap() && test_multifile() && test_dot_slash_removal() && test_long_filename())
     {
         return 0;
     }


### PR DESCRIPTION
Fixes a number redump cuesheets which have long filenames. 256 should be large enough for now as a number of filesystems only support 255 chars in a filename.

redump examples:
- Operative, The - No One Lives Forever (USA) (Disc 1) (Game of the Year Edition).bin
- Quake Mission Pack No. 1 - Scourge of Armagon (USA) (Track 1).bin
- Quake Mission Pack No. 2 - Dissolution of Eternity (USA) (Track 1).bin