### PR TITLE
Fix TOC offset reporting

### DIFF
--- a/src/CUEParser.cpp
+++ b/src/CUEParser.cpp
@@ -63,6 +63,7 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size)
 {
     // Previous track info is needed to track file offset
     uint32_t prev_track_start = m_track_info.track_start;
+    m_track_info.cumulative_offset += m_track_info.unstored_pregap_length;
     uint32_t prev_sector_length = get_sector_length(m_track_info.file_mode, m_track_info.track_mode); // Defaults to 2352 before first track
 
     bool got_file = false;
@@ -123,13 +124,13 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size)
             if (index == 0)
             {
                 // Stored pregap that is present both on CD and in data file
-                m_track_info.track_start = m_track_info.file_start + time;
+                m_track_info.track_start = m_track_info.file_start + time + m_track_info.cumulative_offset;
                 got_pause = true;
             }
             else if (index == 1)
             {
                 // Data content of the track
-                m_track_info.data_start = m_track_info.file_start + time;
+                m_track_info.data_start = m_track_info.file_start + time + m_track_info.cumulative_offset;
                 got_data = true;
             }
         }
@@ -148,11 +149,11 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size)
         if (!got_file)
         {
             // Advance file position by the length of previous track
-            m_track_info.file_offset += (uint64_t)(m_track_info.track_start - prev_track_start) * prev_sector_length;
+            m_track_info.file_offset += (uint64_t)(m_track_info.track_start - (prev_track_start + m_track_info.cumulative_offset)) * prev_sector_length;
         }
 
         // Advance file position by any stored pregap
-        uint32_t stored_pregap = m_track_info.data_start - (m_track_info.track_start + m_track_info.unstored_pregap_length);
+        uint32_t stored_pregap = (m_track_info.data_start - m_track_info.cumulative_offset) - ((m_track_info.track_start - m_track_info.cumulative_offset) + m_track_info.unstored_pregap_length);
         m_track_info.file_offset += (uint64_t)stored_pregap * m_track_info.sector_length;
 
         return &m_track_info;

--- a/src/CUEParser.cpp
+++ b/src/CUEParser.cpp
@@ -153,7 +153,7 @@ const CUETrackInfo *CUEParser::next_track(uint64_t prev_file_size)
         }
 
         // Advance file position by any stored pregap
-        uint32_t stored_pregap = (m_track_info.data_start - m_track_info.cumulative_offset) - ((m_track_info.track_start - m_track_info.cumulative_offset) + m_track_info.unstored_pregap_length);
+        uint32_t stored_pregap = m_track_info.data_start - (m_track_info.track_start + m_track_info.unstored_pregap_length);
         m_track_info.file_offset += (uint64_t)stored_pregap * m_track_info.sector_length;
 
         return &m_track_info;

--- a/src/CUEParser.h
+++ b/src/CUEParser.h
@@ -68,6 +68,9 @@ struct CUETrackInfo
     // These frames of silence are not stored in the underlying data file.
     uint32_t unstored_pregap_length;
 
+    // The cumulative lba offset of unstored data
+    uint32_t cumulative_offset;
+
     // LBA start position of this file
     uint32_t file_start;
 


### PR DESCRIPTION
In ZuluIDE repo, the issue https://github.com/ZuluIDE/ZuluIDE-firmware/issues/179
Shows Alcohol 120% reporting different LBA offsets than the bin/cue
it mounts from the ZuluIDE. That particular bin/cue had both PREGAP
and INDEX 0 directives. The PREGAP offset wasn't carrying over the LBA
offset to the next tracks.

Using an accumulator for PREGAP offset and adding it to data_start
and track_start fixes the issue. 

Added pregap offset adjustment to `test/CUEParser_test.cpp`